### PR TITLE
add compatibility for Joomla 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 GitHub Repo Joomla! plugin
 ==========================
 
-This Joomla! 2.5 plugin embed GitHub repository right into your content.
+This Joomla! 2.5+ plugin embed GitHub repository right into your content.
 
 @author [Jan Linhart](http://escope.cz)
 @licence GNU General Public License version 2 or later

--- a/githubrepo.php
+++ b/githubrepo.php
@@ -59,9 +59,13 @@ class plgContentGithubrepo extends JPlugin
 
                 $document = JFactory::getDocument();
                 $document->addStyleDeclaration('.file.page.active{position:static}');
-                if($jquery){
-                    $document->addScript('//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js');
-                }
+                if ( version_compare( JVERSION, '3.0', '<' ) == 1) { 
+					if($jquery){
+						$document->addScript('//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js');
+					}
+				} else {
+					JHtml::_('jquery.framework');
+				}
                 $document->addScript('plugins/content/githubrepo/repo.js');
                 $document->addScriptDeclaration("jQuery(function(){jQuery('#".$matcheslist[0]."').repo({ user: '".$matcheslist[0]."', name: '".$matcheslist[1]."' });});");
                 

--- a/githubrepo.xml
+++ b/githubrepo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="content">
+<extension version="2.5" type="plugin" group="content" method="upgrade">
     <name>GitHub Repo</name>
     <author>Jan Linhart</author>
     <creationDate>April 2013</creationDate>
@@ -25,7 +25,7 @@
                     type="list"
                     default="1"
                     description="Choose whether you want to load jQuery JavaScript library or not."
-                    label="Load jQuery">
+                    label="Load jQuery (J2.5 Only)">
                     <option value="1">JYES</option>
                     <option value="0">JNO</option>
                 </field>


### PR DESCRIPTION
Current version adds repo.js before jQuery is loaded in J3+.

Commit switches plugin to use built in jQuery in J3+ which corrects the javascript include error.
